### PR TITLE
minor bug fix

### DIFF
--- a/src/FirebaseESP8266.cpp
+++ b/src/FirebaseESP8266.cpp
@@ -5813,7 +5813,7 @@ void FirebaseData::addNodeList(const String *childPath)
 {
     clearNodeList();
     for(size_t i = 0; i< sizeof(childPath)/sizeof(childPath[0]);i++)
-        if(!childPath[i].isEmpty() && childPath[i] !="/")
+        if(childPath[i].length() != 0 && childPath[i] !="/")
             _childNodeList.push_back(childPath[i].c_str());
 }
 


### PR DESCRIPTION
isEmpty method doesn't exist in String class of Arduino library, replaced it with length() method